### PR TITLE
link built .so with libdl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ skeleton.h: make_skeleton.py
 	./make_skeleton.py > $@ || { rm -f skeleton.h; exit 1; }
 
 libXrandr.so: libXrandr.c config.h skeleton.h
-	$(CC) $(CFLAGS) -fPIC -shared -o $@ $<
+	$(CC) $(CFLAGS) -fPIC -shared -o $@ $< -ldl
 
 libXinerama.so.1 libXrandr.so.2: libXrandr.so
 	[ -e $@ ] || ln -s $< $@


### PR DESCRIPTION
This is technically a bug, but it wasn't exposed by the suggested use case (from the README).

I discovered this issue while using the .so with the `LD_PRELOAD` environment variable, where `libdl` hadn't yet been loaded, and thus the built .so could not be loaded.