### PR TITLE
Include missing Ubuntu dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ distribution.
 
 In case of Ubuntu, install the following prerequisites:
 
-     sudo apt-get install xorg-dev libglu1-mesa-dev build-essential python3-gi
+     sudo apt-get install xorg-dev libglu1-mesa-dev build-essential \
+     python3-gi python-gi-dev python-gi-cairo
 
 After installation, use the `fakexrandr-manage` tool to create a configuration (in
 `~/.config/fakexrandr.bin`).


### PR DESCRIPTION
This is a fix for #40. Include the missing Ubuntu dependencies in the listing in the README, in order to make `fakexrandr-manage` work properly.